### PR TITLE
Removed input.txt from input path in config files

### DIFF
--- a/benchmarks/imagefill/floodfill/config.txt
+++ b/benchmarks/imagefill/floodfill/config.txt
@@ -1,4 +1,4 @@
 result_path = /home/himeshi/Projects/workspace/floodfill/klee-out-3/
 source_path = /home/himeshi/Projects/workspace/floodfill/floodfill.c
 ktest_tool_path = /home/himeshi/Projects/Approx/klee/klee/Release+Asserts/bin/ktest-tool
-input_path = /home/himeshi/Projects/workspace/floodfill/input.txt
+input_path = /home/himeshi/Projects/workspace/floodfill/

--- a/benchmarks/imagefill/floodfill/config_andrew_branch_check.txt
+++ b/benchmarks/imagefill/floodfill/config_andrew_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/andrew/software/evaluation/benchmarks/imagefill/floodfill/klee-out-3/
 source_path = /home/andrew/software/evaluation/benchmarks/imagefill/floodfill/floodfill.c
 ktest_tool_path = /home/andrew/software/klee/build/bin/ktest-tool
-input_path = /home/andrew/software/evaluation/benchmarks/imagefill/floodfill/input.txt
+input_path = /home/andrew/software/evaluation/benchmarks/imagefill/floodfill/

--- a/benchmarks/imagefill/floodfill/config_andrew_no_branch_check.txt
+++ b/benchmarks/imagefill/floodfill/config_andrew_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/andrew/software/evaluation/benchmarks/imagefill/floodfill/klee-out-5/
 source_path = /home/andrew/software/evaluation/benchmarks/imagefill/floodfill/floodfill.c
 ktest_tool_path = /home/andrew/software/klee/build/bin/ktest-tool
-input_path = /home/andrew/software/evaluation/benchmarks/imagefill/floodfill/input.txt
+input_path = /home/andrew/software/evaluation/benchmarks/imagefill/floodfill/

--- a/benchmarks/imagefill/floodfill/config_container_branch_check.txt
+++ b/benchmarks/imagefill/floodfill/config_container_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /root/evaluation/benchmarks/imagefill/floodfill/klee-out-3/
 source_path = /root/evaluation/benchmarks/imagefill/floodfill/floodfill.c
 ktest_tool_path = /root/klee/build/bin/ktest-tool
-input_path = /root/evaluation/benchmarks/imagefill/floodfill/input.txt
+input_path = /root/evaluation/benchmarks/imagefill/floodfill/

--- a/benchmarks/imagefill/floodfill/config_container_no_branch_check.txt
+++ b/benchmarks/imagefill/floodfill/config_container_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /root/evaluation/benchmarks/imagefill/floodfill/klee-out-5/
 source_path = /root/evaluation/benchmarks/imagefill/floodfill/floodfill.c
 ktest_tool_path = /root/klee/build/bin/ktest-tool
-input_path = /root/evaluation/benchmarks/imagefill/floodfill/input.txt
+input_path = /root/evaluation/benchmarks/imagefill/floodfill/

--- a/benchmarks/imagefill/floodfill/config_dcsandr_branch_check.txt
+++ b/benchmarks/imagefill/floodfill/config_dcsandr_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/imagefill/floodfill/klee-out-3/
 source_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/imagefill/floodfill/floodfill.c
 ktest_tool_path = /home/dcsandr/projects/fp-analysis/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/imagefill/floodfill/input.txt
+input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/imagefill/floodfill/

--- a/benchmarks/imagefill/floodfill/config_dcsandr_enigma_branch_check.txt
+++ b/benchmarks/imagefill/floodfill/config_dcsandr_enigma_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/software/evaluation/benchmarks/imagefill/floodfill/klee-out-3/
 source_path = /home/dcsandr/software/evaluation/benchmarks/imagefill/floodfill/floodfill.c
 ktest_tool_path = /home/dcsandr/software/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/software/evaluation/benchmarks/imagefill/floodfill/input.txt
+input_path = /home/dcsandr/software/evaluation/benchmarks/imagefill/floodfill/

--- a/benchmarks/imagefill/floodfill/config_dcsandr_enigma_no_branch_check.txt
+++ b/benchmarks/imagefill/floodfill/config_dcsandr_enigma_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/software/evaluation/benchmarks/imagefill/floodfill/klee-out-5/
 source_path = /home/dcsandr/software/evaluation/benchmarks/imagefill/floodfill/floodfill.c
 ktest_tool_path = /home/dcsandr/software/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/software/evaluation/benchmarks/imagefill/floodfill/input.txt
+input_path = /home/dcsandr/software/evaluation/benchmarks/imagefill/floodfill/

--- a/benchmarks/imagefill/floodfill/config_dcsandr_no_branch_check.txt
+++ b/benchmarks/imagefill/floodfill/config_dcsandr_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/imagefill/floodfill/klee-out-5/
 source_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/imagefill/floodfill/floodfill.c
 ktest_tool_path = /home/dcsandr/projects/fp-analysis/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/imagefill/floodfill/input.txt
+input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/imagefill/floodfill/

--- a/benchmarks/scimark/FFTTransformScimark/config.txt
+++ b/benchmarks/scimark/FFTTransformScimark/config.txt
@@ -1,4 +1,4 @@
 result_path = /home/himeshi/Projects/workspace/FFTTransformScimark/klee-out-0/
 source_path = /home/himeshi/Projects/workspace/FFTTransformScimark/fft.c
 ktest_tool_path = /home/himeshi/Projects/Approx/klee/klee/Release+Asserts/bin/ktest-tool
-input_path = /home/himeshi/Projects/workspace/FFTTransformScimark/input.txt
+input_path = /home/himeshi/Projects/workspace/FFTTransformScimark/

--- a/benchmarks/scimark/FFTTransformScimark/config_andrew_branch_check.txt
+++ b/benchmarks/scimark/FFTTransformScimark/config_andrew_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/andrew/software/evaluation/benchmarks/scimark/FFTTransformScimark/klee-out-0/
 source_path = /home/andrew/software/evaluation/benchmarks/scimark/FFTTransformScimark/fft.c
 ktest_tool_path = /home/andrew/software/klee/build/bin/ktest-tool
-input_path = /home/andrew/software/evaluation/benchmarks/scimark/FFTTransformScimark/input.txt
+input_path = /home/andrew/software/evaluation/benchmarks/scimark/FFTTransformScimark/

--- a/benchmarks/scimark/FFTTransformScimark/config_andrew_no_branch_check.txt
+++ b/benchmarks/scimark/FFTTransformScimark/config_andrew_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/andrew/software/evaluation/benchmarks/scimark/FFTTransformScimark/klee-out-2/
 source_path = /home/andrew/software/evaluation/benchmarks/scimark/FFTTransformScimark/fft.c
 ktest_tool_path = /home/andrew/software/klee/build/bin/ktest-tool
-input_path = /home/andrew/software/evaluation/benchmarks/scimark/FFTTransformScimark/input.txt
+input_path = /home/andrew/software/evaluation/benchmarks/scimark/FFTTransformScimark/

--- a/benchmarks/scimark/FFTTransformScimark/config_container_branch_check.txt
+++ b/benchmarks/scimark/FFTTransformScimark/config_container_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /root/evaluation/benchmarks/scimark/FFTTransformScimark/klee-out-0/
 source_path = /root/evaluation/benchmarks/scimark/FFTTransformScimark/fft.c
 ktest_tool_path = /root/klee/build/bin/ktest-tool
-input_path = /root/evaluation/benchmarks/scimark/FFTTransformScimark/input.txt
+input_path = /root/evaluation/benchmarks/scimark/FFTTransformScimark/

--- a/benchmarks/scimark/FFTTransformScimark/config_container_no_branch_check.txt
+++ b/benchmarks/scimark/FFTTransformScimark/config_container_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /root/evaluation/benchmarks/scimark/FFTTransformScimark/klee-out-2/
 source_path = /root/evaluation/benchmarks/scimark/FFTTransformScimark/fft.c
 ktest_tool_path = /root/klee/build/bin/ktest-tool
-input_path = /root/evaluation/benchmarks/scimark/FFTTransformScimark/input.txt
+input_path = /root/evaluation/benchmarks/scimark/FFTTransformScimark/

--- a/benchmarks/scimark/FFTTransformScimark/config_dcsandr_branch_check.txt
+++ b/benchmarks/scimark/FFTTransformScimark/config_dcsandr_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/FFTTransformScimark/klee-out-0/
 source_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/FFTTransformScimark/fft.c
 ktest_tool_path = /home/dcsandr/projects/fp-analysis/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/FFTTransformScimark/input.txt
+input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/FFTTransformScimark/

--- a/benchmarks/scimark/FFTTransformScimark/config_dcsandr_enigma_branch_check.txt
+++ b/benchmarks/scimark/FFTTransformScimark/config_dcsandr_enigma_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/software/evaluation/benchmarks/scimark/FFTTransformScimark/klee-out-0/
 source_path = /home/dcsandr/software/evaluation/benchmarks/scimark/FFTTransformScimark/fft.c
 ktest_tool_path = /home/dcsandr/software/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/software/evaluation/benchmarks/scimark/FFTTransformScimark/input.txt
+input_path = /home/dcsandr/software/evaluation/benchmarks/scimark/FFTTransformScimark/

--- a/benchmarks/scimark/FFTTransformScimark/config_dcsandr_enigma_no_branch_check.txt
+++ b/benchmarks/scimark/FFTTransformScimark/config_dcsandr_enigma_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/software/evaluation/benchmarks/scimark/FFTTransformScimark/klee-out-2/
 source_path = /home/dcsandr/software/evaluation/benchmarks/scimark/FFTTransformScimark/fft.c
 ktest_tool_path = /home/dcsandr/software/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/software/evaluation/benchmarks/scimark/FFTTransformScimark/input.txt
+input_path = /home/dcsandr/software/evaluation/benchmarks/scimark/FFTTransformScimark/

--- a/benchmarks/scimark/FFTTransformScimark/config_dcsandr_no_branch_check.txt
+++ b/benchmarks/scimark/FFTTransformScimark/config_dcsandr_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/FFTTransformScimark/klee-out-2/
 source_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/FFTTransformScimark/fft.c
 ktest_tool_path = /home/dcsandr/projects/fp-analysis/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/FFTTransformScimark/input.txt
+input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/FFTTransformScimark/

--- a/benchmarks/scimark/LUScimark/config.txt
+++ b/benchmarks/scimark/LUScimark/config.txt
@@ -1,4 +1,4 @@
 result_path = /home/himeshi/Projects/workspace/LUScimark/klee-out-2/
 source_path = /home/himeshi/Projects/workspace/LUScimark/lu.c
 ktest_tool_path = /home/himeshi/Projects/Approx/klee/klee/Release+Asserts/bin/ktest-tool
-input_path =  /home/himeshi/Projects/workspace/LUScimark/input.txt
+input_path =  /home/himeshi/Projects/workspace/LUScimark/

--- a/benchmarks/scimark/LUScimark/config_andrew_branch_check.txt
+++ b/benchmarks/scimark/LUScimark/config_andrew_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/andrew/software/evaluation/benchmarks/scimark/LUScimark/klee-out-2/
 source_path = /home/andrew/software/evaluation/benchmarks/scimark/LUScimark/lu.c
 ktest_tool_path = /home/andrew/software/klee/build/bin/ktest-tool
-input_path =  /home/andrew/software/evaluation/benchmarks/scimark/LUScimark/input.txt
+input_path =  /home/andrew/software/evaluation/benchmarks/scimark/LUScimark/

--- a/benchmarks/scimark/LUScimark/config_andrew_no_branch_check.txt
+++ b/benchmarks/scimark/LUScimark/config_andrew_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/andrew/software/evaluation/benchmarks/scimark/LUScimark/klee-out-6/
 source_path = /home/andrew/software/evaluation/benchmarks/scimark/LUScimark/lu.c
 ktest_tool_path = /home/andrew/software/klee/build/bin/ktest-tool
-input_path =  /home/andrew/software/evaluation/benchmarks/scimark/LUScimark/input.txt
+input_path =  /home/andrew/software/evaluation/benchmarks/scimark/LUScimark/

--- a/benchmarks/scimark/LUScimark/config_container_branch_check.txt
+++ b/benchmarks/scimark/LUScimark/config_container_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /root/evaluation/benchmarks/scimark/LUScimark/klee-out-2/
 source_path = /root/evaluation/benchmarks/scimark/LUScimark/lu.c
 ktest_tool_path = /root/klee/build/bin/ktest-tool
-input_path =  /root/evaluation/benchmarks/scimark/LUScimark/input.txt
+input_path =  /root/evaluation/benchmarks/scimark/LUScimark/

--- a/benchmarks/scimark/LUScimark/config_container_no_branch_check.txt
+++ b/benchmarks/scimark/LUScimark/config_container_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /root/evaluation/benchmarks/scimark/LUScimark/klee-out-6/
 source_path = /root/evaluation/benchmarks/scimark/LUScimark/lu.c
 ktest_tool_path = /root/klee/build/bin/ktest-tool
-input_path =  /root/evaluation/benchmarks/scimark/LUScimark/input.txt
+input_path =  /root/evaluation/benchmarks/scimark/LUScimark/

--- a/benchmarks/scimark/LUScimark/config_dcsandr_branch_check.txt
+++ b/benchmarks/scimark/LUScimark/config_dcsandr_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/LUScimark/klee-out-2/
 source_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/LUScimark/lu.c
 ktest_tool_path = /home/dcsandr/projects/fp-analysis/klee/build/bin/ktest-tool
-input_path =  /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/LUScimark/input.txt
+input_path =  /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/LUScimark/

--- a/benchmarks/scimark/LUScimark/config_dcsandr_enigma_branch_check.txt
+++ b/benchmarks/scimark/LUScimark/config_dcsandr_enigma_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/software/evaluation/benchmarks/scimark/LUScimark/klee-out-2/
 source_path = /home/dcsandr/software/evaluation/benchmarks/scimark/LUScimark/lu.c
 ktest_tool_path = /home/dcsandr/software/klee/build/bin/ktest-tool
-input_path =  /home/dcsandr/software/evaluation/benchmarks/scimark/LUScimark/input.txt
+input_path =  /home/dcsandr/software/evaluation/benchmarks/scimark/LUScimark/

--- a/benchmarks/scimark/LUScimark/config_dcsandr_enigma_no_branch_check.txt
+++ b/benchmarks/scimark/LUScimark/config_dcsandr_enigma_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/software/evaluation/benchmarks/scimark/LUScimark/klee-out-6/
 source_path = /home/dcsandr/software/evaluation/benchmarks/scimark/LUScimark/lu.c
 ktest_tool_path = /home/dcsandr/software/klee/build/bin/ktest-tool
-input_path =  /home/dcsandr/software/evaluation/benchmarks/scimark/LUScimark/input.txt
+input_path =  /home/dcsandr/software/evaluation/benchmarks/scimark/LUScimark/

--- a/benchmarks/scimark/LUScimark/config_dcsandr_no_branch_check.txt
+++ b/benchmarks/scimark/LUScimark/config_dcsandr_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/LUScimark/klee-out-6/
 source_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/LUScimark/lu.c
 ktest_tool_path = /home/dcsandr/projects/fp-analysis/klee/build/bin/ktest-tool
-input_path =  /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/LUScimark/input.txt
+input_path =  /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/LUScimark/

--- a/benchmarks/scimark/MonteCarloScimark/config.txt
+++ b/benchmarks/scimark/MonteCarloScimark/config.txt
@@ -1,4 +1,4 @@
 result_path = /home/himeshi/Projects/workspace/MonteCarloScimark/klee-out-4/
 source_path = /home/himeshi/Projects/workspace/MonteCarloScimark/montecarlo.c
 ktest_tool_path = /home/himeshi/Projects/Approx/klee/klee/Release+Asserts/bin/ktest-tool
-input_path =  /home/himeshi/Projects/workspace/MonteCarloScimark/input.txt
+input_path =  /home/himeshi/Projects/workspace/MonteCarloScimark/

--- a/benchmarks/scimark/MonteCarloScimark/config_andrew_branch_check.txt
+++ b/benchmarks/scimark/MonteCarloScimark/config_andrew_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/andrew/software/evaluation/benchmarks/scimark/MonteCarloScimark/klee-out-4/
 source_path = /home/andrew/software/evaluation/benchmarks/scimark/MonteCarloScimark/montecarlo.c
 ktest_tool_path = /home/andrew/software/klee/build/bin/ktest-tool
-input_path = /home/andrew/software/evaluation/benchmarks/scimark/MonteCarloScimark/input.txt
+input_path = /home/andrew/software/evaluation/benchmarks/scimark/MonteCarloScimark/

--- a/benchmarks/scimark/MonteCarloScimark/config_andrew_no_branch_check.txt
+++ b/benchmarks/scimark/MonteCarloScimark/config_andrew_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/andrew/software/evaluation/benchmarks/scimark/MonteCarloScimark/klee-out-6/
 source_path = /home/andrew/software/evaluation/benchmarks/scimark/MonteCarloScimark/montecarlo.c
 ktest_tool_path = /home/andrew/software/klee/build/bin/ktest-tool
-input_path = /home/andrew/software/evaluation/benchmarks/scimark/MonteCarloScimark/input.txt
+input_path = /home/andrew/software/evaluation/benchmarks/scimark/MonteCarloScimark/

--- a/benchmarks/scimark/MonteCarloScimark/config_container_branch_check.txt
+++ b/benchmarks/scimark/MonteCarloScimark/config_container_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /root/evaluation/benchmarks/scimark/MonteCarloScimark/klee-out-4/
 source_path = /root/evaluation/benchmarks/scimark/MonteCarloScimark/montecarlo.c
 ktest_tool_path = /root/klee/build/bin/ktest-tool
-input_path = /root/evaluation/benchmarks/scimark/MonteCarloScimark/input.txt
+input_path = /root/evaluation/benchmarks/scimark/MonteCarloScimark/

--- a/benchmarks/scimark/MonteCarloScimark/config_container_no_branch_check.txt
+++ b/benchmarks/scimark/MonteCarloScimark/config_container_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /root/evaluation/benchmarks/scimark/MonteCarloScimark/klee-out-6/
 source_path = /root/evaluation/benchmarks/scimark/MonteCarloScimark/montecarlo.c
 ktest_tool_path = /root/klee/build/bin/ktest-tool
-input_path = /root/evaluation/benchmarks/scimark/MonteCarloScimark/input.txt
+input_path = /root/evaluation/benchmarks/scimark/MonteCarloScimark/

--- a/benchmarks/scimark/MonteCarloScimark/config_dcsandr_branch_check.txt
+++ b/benchmarks/scimark/MonteCarloScimark/config_dcsandr_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/MonteCarloScimark/klee-out-4/
 source_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/MonteCarloScimark/montecarlo.c
 ktest_tool_path = /home/dcsandr/projects/fp-analysis/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/MonteCarloScimark/input.txt
+input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/MonteCarloScimark/

--- a/benchmarks/scimark/MonteCarloScimark/config_dcsandr_enigma_branch_check.txt
+++ b/benchmarks/scimark/MonteCarloScimark/config_dcsandr_enigma_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/software/evaluation/benchmarks/scimark/MonteCarloScimark/klee-out-4/
 source_path = /home/dcsandr/software/evaluation/benchmarks/scimark/MonteCarloScimark/montecarlo.c
 ktest_tool_path = /home/dcsandr/software/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/software/evaluation/benchmarks/scimark/MonteCarloScimark/input.txt
+input_path = /home/dcsandr/software/evaluation/benchmarks/scimark/MonteCarloScimark/

--- a/benchmarks/scimark/MonteCarloScimark/config_dcsandr_enigma_no_branch_check.txt
+++ b/benchmarks/scimark/MonteCarloScimark/config_dcsandr_enigma_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/software/evaluation/benchmarks/scimark/MonteCarloScimark/klee-out-6/
 source_path = /home/dcsandr/software/evaluation/benchmarks/scimark/MonteCarloScimark/montecarlo.c
 ktest_tool_path = /home/dcsandr/software/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/software/evaluation/benchmarks/scimark/MonteCarloScimark/input.txt
+input_path = /home/dcsandr/software/evaluation/benchmarks/scimark/MonteCarloScimark/

--- a/benchmarks/scimark/MonteCarloScimark/config_dcsandr_no_branch_check.txt
+++ b/benchmarks/scimark/MonteCarloScimark/config_dcsandr_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/MonteCarloScimark/klee-out-6/
 source_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/MonteCarloScimark/montecarlo.c
 ktest_tool_path = /home/dcsandr/projects/fp-analysis/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/MonteCarloScimark/input.txt
+input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/MonteCarloScimark/

--- a/benchmarks/scimark/SORScimark/config.txt
+++ b/benchmarks/scimark/SORScimark/config.txt
@@ -1,4 +1,4 @@
 result_path = /home/himeshi/Projects/workspace/SORScimark/klee-out-0/
 source_path = /home/himeshi/Projects/workspace/SORScimark/sor.c
 ktest_tool_path = /home/himeshi/Projects/Approx/klee/klee/Release+Asserts/bin/ktest-tool
-input_path = /home/himeshi/Projects/workspace/SORScimark/input.txt
+input_path = /home/himeshi/Projects/workspace/SORScimark/

--- a/benchmarks/scimark/SORScimark/config_andrew_branch_check.txt
+++ b/benchmarks/scimark/SORScimark/config_andrew_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/andrew/software/evaluation/benchmarks/scimark/SORScimark/klee-out-0/
 source_path = /home/andrew/software/evaluation/benchmarks/scimark/SORScimark/sor.c
 ktest_tool_path = /home/andrew/software/klee/build/bin/ktest-tool
-input_path = /home/andrew/software/evaluation/benchmarks/scimark/SORScimark/input.txt
+input_path = /home/andrew/software/evaluation/benchmarks/scimark/SORScimark/

--- a/benchmarks/scimark/SORScimark/config_andrew_no_branch_check.txt
+++ b/benchmarks/scimark/SORScimark/config_andrew_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/andrew/software/evaluation/benchmarks/scimark/SORScimark/klee-out-1/
 source_path = /home/andrew/software/evaluation/benchmarks/scimark/SORScimark/sor.c
 ktest_tool_path = /home/andrew/software/klee/build/bin/ktest-tool
-input_path = /home/andrew/software/evaluation/benchmarks/scimark/SORScimark/input.txt
+input_path = /home/andrew/software/evaluation/benchmarks/scimark/SORScimark/

--- a/benchmarks/scimark/SORScimark/config_container_branch_check.txt
+++ b/benchmarks/scimark/SORScimark/config_container_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /root/evaluation/benchmarks/scimark/SORScimark/klee-out-0/
 source_path = /root/evaluation/benchmarks/scimark/SORScimark/sor.c
 ktest_tool_path = /root/klee/build/bin/ktest-tool
-input_path = /root/evaluation/benchmarks/scimark/SORScimark/input.txt
+input_path = /root/evaluation/benchmarks/scimark/SORScimark/

--- a/benchmarks/scimark/SORScimark/config_container_no_branch_check.txt
+++ b/benchmarks/scimark/SORScimark/config_container_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /root/evaluation/benchmarks/scimark/SORScimark/klee-out-1/
 source_path = /root/evaluation/benchmarks/scimark/SORScimark/sor.c
 ktest_tool_path = /root/klee/build/bin/ktest-tool
-input_path = /root/evaluation/benchmarks/scimark/SORScimark/input.txt
+input_path = /root/evaluation/benchmarks/scimark/SORScimark/

--- a/benchmarks/scimark/SORScimark/config_dcsandr_branch_check.txt
+++ b/benchmarks/scimark/SORScimark/config_dcsandr_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/SORScimark/klee-out-0/
 source_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/SORScimark/sor.c
 ktest_tool_path = /home/dcsandr/projects/fp-analysis/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/SORScimark/input.txt
+input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/SORScimark/

--- a/benchmarks/scimark/SORScimark/config_dcsandr_enigma_branch_check.txt
+++ b/benchmarks/scimark/SORScimark/config_dcsandr_enigma_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/software/evaluation/benchmarks/scimark/SORScimark/klee-out-0/
 source_path = /home/dcsandr/software/evaluation/benchmarks/scimark/SORScimark/sor.c
 ktest_tool_path = /home/dcsandr/software/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/software/evaluation/benchmarks/scimark/SORScimark/input.txt
+input_path = /home/dcsandr/software/evaluation/benchmarks/scimark/SORScimark/

--- a/benchmarks/scimark/SORScimark/config_dcsandr_enigma_no_branch_check.txt
+++ b/benchmarks/scimark/SORScimark/config_dcsandr_enigma_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/software/evaluation/benchmarks/scimark/SORScimark/klee-out-1/
 source_path = /home/dcsandr/software/evaluation/benchmarks/scimark/SORScimark/sor.c
 ktest_tool_path = /home/dcsandr/software/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/software/evaluation/benchmarks/scimark/SORScimark/input.txt
+input_path = /home/dcsandr/software/evaluation/benchmarks/scimark/SORScimark/

--- a/benchmarks/scimark/SORScimark/config_dcsandr_no_branch_check.txt
+++ b/benchmarks/scimark/SORScimark/config_dcsandr_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/SORScimark/klee-out-1/
 source_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/SORScimark/sor.c
 ktest_tool_path = /home/dcsandr/projects/fp-analysis/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/SORScimark/input.txt
+input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/SORScimark/

--- a/benchmarks/scimark/SparseMatMulScimark/config.txt
+++ b/benchmarks/scimark/SparseMatMulScimark/config.txt
@@ -1,4 +1,4 @@
 result_path = /home/himeshi/Projects/workspace/SparseMatMulScimark/klee-out-3/
 source_path = /home/himeshi/Projects/workspace/SparseMatMulScimark/sparsematmul.c
 ktest_tool_path = /home/himeshi/Projects/Approx/klee/klee/Release+Asserts/bin/ktest-tool
-input_path = /home/himeshi/Projects/workspace/SparseMatMulScimark/input.txt
+input_path = /home/himeshi/Projects/workspace/SparseMatMulScimark/

--- a/benchmarks/scimark/SparseMatMulScimark/config_andrew_branch_check.txt
+++ b/benchmarks/scimark/SparseMatMulScimark/config_andrew_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/andrew/software/evaluation/benchmarks/scimark/SparseMatMulScimark/klee-out-3/
 source_path = /home/andrew/software/evaluation/benchmarks/scimark/SparseMatMulScimark/sparsematmul.c
 ktest_tool_path = /home/andrew/software/klee/build/bin/ktest-tool
-input_path = /home/andrew/software/evaluation/benchmarks/scimark/SparseMatMulScimark/input.txt
+input_path = /home/andrew/software/evaluation/benchmarks/scimark/SparseMatMulScimark/

--- a/benchmarks/scimark/SparseMatMulScimark/config_andrew_no_branch_check.txt
+++ b/benchmarks/scimark/SparseMatMulScimark/config_andrew_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/andrew/software/evaluation/benchmarks/scimark/SparseMatMulScimark/klee-out-5/
 source_path = /home/andrew/software/evaluation/benchmarks/scimark/SparseMatMulScimark/sparsematmul.c
 ktest_tool_path = /home/andrew/software/klee/build/bin/ktest-tool
-input_path = /home/andrew/software/evaluation/benchmarks/scimark/SparseMatMulScimark/input.txt
+input_path = /home/andrew/software/evaluation/benchmarks/scimark/SparseMatMulScimark/

--- a/benchmarks/scimark/SparseMatMulScimark/config_container_branch_check.txt
+++ b/benchmarks/scimark/SparseMatMulScimark/config_container_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /root/evaluation/benchmarks/scimark/SparseMatMulScimark/klee-out-3/
 source_path = /root/evaluation/benchmarks/scimark/SparseMatMulScimark/sparsematmul.c
 ktest_tool_path = /root/klee/build/bin/ktest-tool
-input_path = /root/evaluation/benchmarks/scimark/SparseMatMulScimark/input.txt
+input_path = /root/evaluation/benchmarks/scimark/SparseMatMulScimark/

--- a/benchmarks/scimark/SparseMatMulScimark/config_container_no_branch_check.txt
+++ b/benchmarks/scimark/SparseMatMulScimark/config_container_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /root/evaluation/benchmarks/scimark/SparseMatMulScimark/klee-out-5/
 source_path = /root/evaluation/benchmarks/scimark/SparseMatMulScimark/sparsematmul.c
 ktest_tool_path = /root/klee/build/bin/ktest-tool
-input_path = /root/evaluation/benchmarks/scimark/SparseMatMulScimark/input.txt
+input_path = /root/evaluation/benchmarks/scimark/SparseMatMulScimark/

--- a/benchmarks/scimark/SparseMatMulScimark/config_dcsandr_branch_check.txt
+++ b/benchmarks/scimark/SparseMatMulScimark/config_dcsandr_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/SparseMatMulScimark/klee-out-3/
 source_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/SparseMatMulScimark/sparsematmul.c
 ktest_tool_path = /home/dcsandr/projects/fp-analysis/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/SparseMatMulScimark/input.txt
+input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/SparseMatMulScimark/

--- a/benchmarks/scimark/SparseMatMulScimark/config_dcsandr_enigma_branch_check.txt
+++ b/benchmarks/scimark/SparseMatMulScimark/config_dcsandr_enigma_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/software/evaluation/benchmarks/scimark/SparseMatMulScimark/klee-out-3/
 source_path = /home/dcsandr/software/evaluation/benchmarks/scimark/SparseMatMulScimark/sparsematmul.c
 ktest_tool_path = /home/dcsandr/software/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/software/evaluation/benchmarks/scimark/SparseMatMulScimark/input.txt
+input_path = /home/dcsandr/software/evaluation/benchmarks/scimark/SparseMatMulScimark/

--- a/benchmarks/scimark/SparseMatMulScimark/config_dcsandr_enigma_no_branch_check.txt
+++ b/benchmarks/scimark/SparseMatMulScimark/config_dcsandr_enigma_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/software/evaluation/benchmarks/scimark/SparseMatMulScimark/klee-out-5/
 source_path = /home/dcsandr/software/evaluation/benchmarks/scimark/SparseMatMulScimark/sparsematmul.c
 ktest_tool_path = /home/dcsandr/software/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/software/evaluation/benchmarks/scimark/SparseMatMulScimark/input.txt
+input_path = /home/dcsandr/software/evaluation/benchmarks/scimark/SparseMatMulScimark/

--- a/benchmarks/scimark/SparseMatMulScimark/config_dcsandr_no_branch_check.txt
+++ b/benchmarks/scimark/SparseMatMulScimark/config_dcsandr_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/SparseMatMulScimark/klee-out-5/
 source_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/SparseMatMulScimark/sparsematmul.c
 ktest_tool_path = /home/dcsandr/projects/fp-analysis/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/SparseMatMulScimark/input.txt
+input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/scimark/SparseMatMulScimark/

--- a/benchmarks/simpleRayTracer/config.txt
+++ b/benchmarks/simpleRayTracer/config.txt
@@ -1,4 +1,4 @@
 result_path = /home/himeshi/Projects/workspace/simpleRayTracer/klee-out-3/
 source_path = /home/himeshi/Projects/workspace/simpleRayTracer/plane.c
 ktest_tool_path = /home/himeshi/Projects/Approx/klee/klee/Release+Asserts/bin/ktest-tool
-input_path = /home/himeshi/Projects/workspace/simpleRayTracer/input.txt
+input_path = /home/himeshi/Projects/workspace/simpleRayTracer/

--- a/benchmarks/simpleRayTracer/config_andrew_branch_check.txt
+++ b/benchmarks/simpleRayTracer/config_andrew_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/andrew/software/evaluation/benchmarks/simpleRayTracer/klee-out-3/
 source_path = /home/andrew/software/evaluation/benchmarks/simpleRayTracer/plane.c
 ktest_tool_path = /home/andrew/software/klee/build/bin/ktest-tool
-input_path = /home/andrew/software/evaluation/benchmarks/simpleRayTracer/input.txt
+input_path = /home/andrew/software/evaluation/benchmarks/simpleRayTracer/

--- a/benchmarks/simpleRayTracer/config_andrew_no_branch_check.txt
+++ b/benchmarks/simpleRayTracer/config_andrew_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/andrew/software/evaluation/benchmarks/simpleRayTracer/klee-out-6/
 source_path = /home/andrew/software/evaluation/benchmarks/simpleRayTracer/plane.c
 ktest_tool_path = /home/andrew/software/klee/build/bin/ktest-tool
-input_path = /home/andrew/software/evaluation/benchmarks/simpleRayTracer/input.txt
+input_path = /home/andrew/software/evaluation/benchmarks/simpleRayTracer/

--- a/benchmarks/simpleRayTracer/config_container_branch_check.txt
+++ b/benchmarks/simpleRayTracer/config_container_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /root/evaluation/benchmarks/simpleRayTracer/klee-out-3/
 source_path = /root/evaluation/benchmarks/simpleRayTracer/plane.c
 ktest_tool_path = /root/klee/build/bin/ktest-tool
-input_path = /root/evaluation/benchmarks/simpleRayTracer/input.txt
+input_path = /root/evaluation/benchmarks/simpleRayTracer/

--- a/benchmarks/simpleRayTracer/config_container_no_branch_check.txt
+++ b/benchmarks/simpleRayTracer/config_container_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /root/evaluation/benchmarks/simpleRayTracer/klee-out-6/
 source_path = /root/evaluation/benchmarks/simpleRayTracer/plane.c
 ktest_tool_path = /root/klee/build/bin/ktest-tool
-input_path = /root/evaluation/benchmarks/simpleRayTracer/input.txt
+input_path = /root/evaluation/benchmarks/simpleRayTracer/

--- a/benchmarks/simpleRayTracer/config_dcsandr_branch_check.txt
+++ b/benchmarks/simpleRayTracer/config_dcsandr_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/simpleRayTracer/klee-out-3/
 source_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/simpleRayTracer/plane.c
 ktest_tool_path = /home/dcsandr/projects/fp-analysis/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/simpleRayTracer/input.txt
+input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/simpleRayTracer/

--- a/benchmarks/simpleRayTracer/config_dcsandr_enigma_branch_check.txt
+++ b/benchmarks/simpleRayTracer/config_dcsandr_enigma_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/software/evaluation/benchmarks/simpleRayTracer/klee-out-3/
 source_path = /home/dcsandr/software/evaluation/benchmarks/simpleRayTracer/plane.c
 ktest_tool_path = /home/dcsandr/software/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/software/evaluation/benchmarks/simpleRayTracer/input.txt
+input_path = /home/dcsandr/software/evaluation/benchmarks/simpleRayTracer/

--- a/benchmarks/simpleRayTracer/config_dcsandr_enigma_no_branch_check.txt
+++ b/benchmarks/simpleRayTracer/config_dcsandr_enigma_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/software/evaluation/benchmarks/simpleRayTracer/klee-out-6/
 source_path = /home/dcsandr/software/evaluation/benchmarks/simpleRayTracer/plane.c
 ktest_tool_path = /home/dcsandr/software/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/software/evaluation/benchmarks/simpleRayTracer/input.txt
+input_path = /home/dcsandr/software/evaluation/benchmarks/simpleRayTracer/

--- a/benchmarks/simpleRayTracer/config_dcsandr_no_branch_check.txt
+++ b/benchmarks/simpleRayTracer/config_dcsandr_no_branch_check.txt
@@ -1,4 +1,4 @@
 result_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/simpleRayTracer/klee-out-6/
 source_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/simpleRayTracer/plane.c
 ktest_tool_path = /home/dcsandr/projects/fp-analysis/klee/build/bin/ktest-tool
-input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/simpleRayTracer/input.txt
+input_path = /home/dcsandr/projects/fp-analysis/evaluation/benchmarks/simpleRayTracer/


### PR DESCRIPTION
New version of approximabily searches for input_NN.txt first (with NN some numbers) and fall back to input.txt. So the name input.txt need not be specified.

@Himeshi I will simply merge this for now. It contains just changes to the config files.